### PR TITLE
Fix Changeset edit

### DIFF
--- a/app/changesets/show/template.hbs
+++ b/app/changesets/show/template.hbs
@@ -38,7 +38,7 @@
 </dl>
 
 {{#unless model.applied }}
-  {{#link-to 'changesets.edit' model class="btn btn-primary" }}Edit changeset{{/link-to}}
+  {{#link-to 'changesets.edit' model.id class="btn btn-primary" }}Edit changeset{{/link-to}}
   <input type="button" class="btn btn-danger" {{action 'apply'}} value="Apply changeset">
 {{/unless}}
 


### PR DESCRIPTION
changesets.show and changesets.edit have different model hook returns; changeset.edit includes a list of users. Pass the changeset id so the models are reloaded correctly.

Resolves #82 

