### PR TITLE
Polyline decorator

### DIFF
--- a/app/components/route-map/route-stop-pattern/template.hbs
+++ b/app/components/route-map/route-stop-pattern/template.hbs
@@ -1,5 +1,5 @@
-{{#polyline-layer onAdd=rspAdded locations=model.coordinates}}
-{{/polyline-layer}}
 {{#polyline-decorator latlngs=model.coordinates patterns=model.patterns}}
   <p>{{model.onestop_id}}</p>
 {{/polyline-decorator}}
+{{#polyline-layer onAdd=rspAdded locations=model.coordinates}}
+{{/polyline-layer}}

--- a/app/components/route-map/route-stop-pattern/template.hbs
+++ b/app/components/route-map/route-stop-pattern/template.hbs
@@ -1,3 +1,5 @@
-{{#polyline-layer onAdd="rspAdded" locations=model.coordinates}}
-  <p>{{model.onestop_id}}</p>
+{{#polyline-layer onAdd=rspAdded locations=model.coordinates}}
 {{/polyline-layer}}
+{{#polyline-decorator latlngs=model.coordinates patterns=model.patterns}}
+  <p>{{model.onestop_id}}</p>
+{{/polyline-decorator}}

--- a/app/route-stop-pattern/model.js
+++ b/app/route-stop-pattern/model.js
@@ -17,6 +17,9 @@ export default EntityWithActivityModel.extend({
 	geometry: DS.attr(),
 	tags: DS.attr(),
 	issues: DS.hasMany('issue'),
+	patterns: [
+		{offset: 0, repeat: 20, symbol: L.Symbol.arrowHead({pixelSize: 12, pathOptions: {fillOpacity: 1, weight: 0}})}
+	],
 	stopsWithDistances: Ember.computed('stop_pattern', function(){
 		var self = this;
 		var args = {};

--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     "leaflet": "~0.7.2",
     "leaflet-measure": "ljagis/leaflet-measure#^2.0.1",
     "leaflet-draw": "~0.2.4-dev",
-    "leaflet.markercluster": "^0.5.0"
+    "leaflet.markercluster": "^0.5.0",
+    "Leaflet.PolylineDecorator": "bbecquet/Leaflet.PolylineDecorator#leaflet-0.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "ember-leaflet-measure": "transitland/ember-leaflet-measure#master",
     "ember-leaflet-draw": "transitland/ember-leaflet-draw#master",
-    "ember-leaflet-polyline-decorator": "ember-leaflet-polyline-decorator"
+    "ember-leaflet-polyline-decorator": "transitland/ember-leaflet-polyline-decorator#master"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "ember-leaflet-measure": "transitland/ember-leaflet-measure#master",
-    "ember-leaflet-draw": "transitland/ember-leaflet-draw#master"
+    "ember-leaflet-draw": "transitland/ember-leaflet-draw#master",
+    "ember-leaflet-polyline-decorator": "ember-leaflet-polyline-decorator"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-toggle": "^1.0.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-cli-version-checker": "^1.2.0",
     "ember-component-css": "0.2.0-beta.4",
     "ember-data": "^2.5.0",
     "ember-export-application-global": "^1.0.5",


### PR DESCRIPTION
Route Stop Pattern geometry lines are now displayed as polylines with added polyline decoration from:

https://github.com/bbecquet/Leaflet.PolylineDecorator

and

https://github.com/transitland/ember-leaflet-polyline-decorator