### PR TITLE
Polyline decorator build fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-toggle": "^1.0.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-cli-version-checker": "^1.2.0",
     "ember-component-css": "0.2.0-beta.4",
     "ember-data": "^2.5.0",
     "ember-export-application-global": "^1.0.5",


### PR DESCRIPTION
Removing "ember-cli-version-checker" as it didn't seem to be there before.