### PR TITLE
rootURL fixes

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/dispatcher.css">
+    <link rel="stylesheet" href="assets/vendor.css">
+    <link rel="stylesheet" href="assets/dispatcher.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/dispatcher.js"></script>
+    <script src="assets/vendor.js"></script>
+    <script src="assets/dispatcher.js"></script>
 
     {{content-for "body-footer"}}
   </body>


### PR DESCRIPTION
Previous update results in urls with 2x prepended rootURL.

ex:
`https://d2tkmr00hnrtoq.cloudfront.net/dispatcher/dispatcher/assets/vendor-ba20d8a864306646c33baed1203ed651.css`